### PR TITLE
Implement MapReduce

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,3 +1,9 @@
 module 6.824
 
-go 1.15
+go 1.18
+
+require (
+	github.com/google/uuid v1.3.0
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
+	golang.org/x/net v0.0.0-20220728030405-41545e8bf201
+)

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,0 +1,6 @@
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
+golang.org/x/net v0.0.0-20220728030405-41545e8bf201 h1:bvOltf3SADAfG05iRml8lAB3qjoEX5RCyN4K6G5v3N0=
+golang.org/x/net v0.0.0-20220728030405-41545e8bf201/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=

--- a/src/main/mrworker.go
+++ b/src/main/mrworker.go
@@ -10,11 +10,14 @@ package main
 // Please do not change this file.
 //
 
-import "6.824/mr"
-import "plugin"
-import "os"
-import "fmt"
-import "log"
+import (
+	"fmt"
+	"log"
+	"os"
+	"plugin"
+
+	"6.824/mr"
+)
 
 func main() {
 	if len(os.Args) != 2 {
@@ -24,7 +27,7 @@ func main() {
 
 	mapf, reducef := loadPlugin(os.Args[1])
 
-	mr.Worker(mapf, reducef)
+	mr.NewWorker(mapf, reducef)
 }
 
 //

--- a/src/mr/coordinator.go
+++ b/src/mr/coordinator.go
@@ -1,45 +1,247 @@
 package mr
 
 import (
+	"context"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
 	"net/rpc"
 	"os"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
 )
 
-type Worker struct {
-	socket string
-	status string
+type taskStatus int
+
+const (
+	pending taskStatus = iota
+	running
+	done
+)
+
+type taskId string
+
+type mapTask struct {
+	Id     taskId
+	Status taskStatus
+	File   string
+}
+
+type mapResult struct {
+	TaskId            taskId
+	IntermediateFiles map[int]string // one per partition
+}
+
+type reduceTask struct {
+	Partition         int
+	Status            taskStatus
+	IntermediateFiles map[string]bool
+}
+
+type reduceResult struct {
+	Partition int
+}
+
+type coordinatedWorker struct {
+	WorkerId    string
+	Endpoint    Endpoint
+	NPartitions int
 }
 
 type Coordinator struct {
-	workers map[string]Worker
+	done                chan bool
+	shutdownWorkers     chan struct{}
+	isServerOffline     chan struct{}
+	workers             sync.WaitGroup
+	nPartitions         int
+	scheduledMapTask    chan mapTask
+	scheduledReduceTask chan reduceTask
+	failedMapTask       chan mapTask
+	failedReduceTask    chan reduceTask
+	mapResults          chan mapResult
+	reduceResults       chan reduceResult
 }
 
 //
-// RPC handler to register that a worker is idle
-// Should also be used to register a new worker
+// create a Coordinator
+// main/mrcoordinator.go calls this function
+// files is the list of map tasks
+// nReduce is the number of reduce tasks to use
 //
-func (c *Coordinator) IdleWorker(args *ReportIdleArgs, reply *ReportIdleReply) error {
-	if worker, ok := c.workers[args.Sockname]; ok {
-		worker.status = "IDLE"
-		return nil
+func MakeCoordinator(files []string, nReduce int) *Coordinator {
+	c := Coordinator{
+		workers:             sync.WaitGroup{},
+		isServerOffline:     make(chan struct{}),
+		shutdownWorkers:     make(chan struct{}),
+		done:                make(chan bool),
+		nPartitions:         nReduce,
+		scheduledMapTask:    make(chan mapTask, len(files)),
+		scheduledReduceTask: make(chan reduceTask, nReduce),
+		failedMapTask:       make(chan mapTask, 1),
+		failedReduceTask:    make(chan reduceTask, 1),
+		mapResults:          make(chan mapResult, 1),
+		reduceResults:       make(chan reduceResult, 1),
 	}
-	c.workers[args.Sockname] = Worker{
-		socket: args.Sockname,
-		status: "IDLE",
+
+	c.server()
+	c.scheduler(files, nReduce)
+
+	return &c
+}
+
+//
+// A worker calls this method via RPC to register itself for receiving work
+//
+func (c *Coordinator) RequestRegistration(args *RegistrationRequestArgs, reply *RegistrationRequestReply) error {
+	worker := coordinatedWorker{
+		WorkerId:    args.WorkerId,
+		Endpoint:    args.WorkerEndpoint,
+		NPartitions: c.nPartitions,
 	}
+	c.registerWorker(worker)
 	return nil
 }
 
 //
-// an example RPC handler.
+// main/mrcoordinator.go calls Done() periodically to find out
+// if the entire job has finished.
+// Will block until the job has finished.
 //
-// the RPC argument and reply types are defined in rpc.go.
-//
-func (c *Coordinator) Example(args *ExampleArgs, reply *ExampleReply) error {
-	reply.Y = args.X + 1
+func (c *Coordinator) Done() bool {
+	return <-c.done
+}
+
+func (c *Coordinator) registerWorker(w coordinatedWorker) {
+	log.Printf("worker %v has registered\n", w.WorkerId)
+	c.workers.Add(1)
+	healthCheckFailure := make(chan bool, 1)
+	go func() {
+		log.Printf("starting health checker for worker %v\n", w.WorkerId)
+		t := time.NewTicker(time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-c.shutdownWorkers:
+				log.Printf("worker %v has been shut down, stopping health check\n", w.WorkerId)
+				return
+			case <-t.C:
+				if err := pingWorker(w); err != nil {
+					fmt.Fprintf(os.Stderr, "health check for worker %s failed", w.WorkerId)
+					healthCheckFailure <- true
+					return
+				}
+			}
+		}
+	}()
+
+	go func() {
+		log.Printf("worker %v starts to consume tasks from the scheduler\n", w.WorkerId)
+		defer c.workers.Done()
+		var mapTasks []mapTask
+		var reduceTasks []reduceTask
+		for {
+			select {
+			case task := <-c.scheduledMapTask:
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				result, err := w.mapf(ctx, task)
+				if err != nil {
+					c.failedMapTask <- task
+					break
+				}
+				mapTasks = append(mapTasks, task)
+				c.mapResults <- result
+			case task := <-c.scheduledReduceTask:
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				result, err := w.reducef(ctx, task)
+				if err != nil {
+					c.failedReduceTask <- task
+					break
+				}
+				reduceTasks = append(reduceTasks, task)
+				c.reduceResults <- result
+			case <-healthCheckFailure:
+				// handling of a health check failure and executing some task cannot happen concurrently
+				for _, task := range mapTasks {
+					log.Printf("rescheduling map task %v\n", task.Id)
+					c.failedMapTask <- task
+				}
+				for _, task := range reduceTasks {
+					log.Printf("rescheduling reduce task %v\n", task.Partition)
+					c.failedReduceTask <- task
+				}
+				return
+			case <-c.shutdownWorkers:
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				err := w.shutdown(ctx)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, fmt.Errorf("failed to request worker %s shutdown", w.WorkerId))
+				}
+				return
+			}
+		}
+	}()
+}
+
+func (w *coordinatedWorker) mapf(ctx context.Context, task mapTask) (mapResult, error) {
+	args := AssignMapTaskArgs{
+		TaskId:      string(task.Id),
+		File:        task.File,
+		NPartitions: w.NPartitions,
+	}
+	reply := DoneMapTaskReply{}
+	err := call(ctx, w.Endpoint, "Worker.AssignMapTask", &args, &reply)
+	mapResult := mapResult{}
+	if err != nil {
+		return mapResult, err
+	}
+	mapResult.TaskId = task.Id
+	mapResult.IntermediateFiles = reply.PartitionedKVA
+	return mapResult, nil
+}
+
+func (w *coordinatedWorker) reducef(ctx context.Context, task reduceTask) (reduceResult, error) {
+	var intermediates []string
+	for intermediate := range task.IntermediateFiles {
+		intermediates = append(intermediates, intermediate)
+	}
+	args := AssignReduceTaskArgs{
+		Partition:     task.Partition,
+		Intermediates: intermediates,
+	}
+	reply := DoneReduceTaskReply{}
+	err := call(ctx, w.Endpoint, "Worker.AssignReduceTask", &args, &reply)
+	reduceResult := reduceResult{}
+	if err != nil {
+		return reduceResult, err
+	}
+	reduceResult.Partition = task.Partition
+	return reduceResult, nil
+}
+
+func (w *coordinatedWorker) shutdown(ctx context.Context) error {
+	args := ShutdownArgs{}
+	reply := ShutdownReply{}
+	err := call(ctx, w.Endpoint, "Worker.Shutdown", &args, &reply)
+	return err
+}
+
+func pingWorker(worker coordinatedWorker) error {
+	log.Printf("pinging worker %v\n", worker.WorkerId)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	healthArgs := HealthCheckArgs{}
+	healthReply := HealthCheckReply{}
+	if err := call(ctx, worker.Endpoint, "Worker.HealthCheck", &healthArgs, &healthReply); err != nil {
+		return HealthCheckFailedErr{
+			Message: fmt.Sprintf("pinging worker %v failed: %v", worker.WorkerId, err),
+		}
+	}
 	return nil
 }
 
@@ -50,39 +252,102 @@ func (c *Coordinator) server() {
 	rpc.Register(c)
 	rpc.HandleHTTP()
 	//l, e := net.Listen("tcp", ":1234")
-	sockname := coordinatorSock()
+	sockname := string(coordinatorEndpoint())
 	os.Remove(sockname)
 	l, e := net.Listen("unix", sockname)
 	if e != nil {
 		log.Fatal("listen error:", e)
 	}
-	go http.Serve(l, nil)
+	go func() {
+		go func() {
+			<-c.shutdownWorkers // if workers are requested to shutdown, we don't want to accept any new workers
+			l.Close()
+			close(c.isServerOffline)
+		}()
+		http.Serve(l, nil)
+	}()
 }
 
-//
-// main/mrcoordinator.go calls Done() periodically to find out
-// if the entire job has finished.
-//
-func (c *Coordinator) Done() bool {
-	ret := false
-
-	// Your code here.
-
-	return ret
-}
-
-//
-// create a Coordinator.
-// main/mrcoordinator.go calls this function.
-// nReduce is the number of reduce tasks to use.
-//
-func MakeCoordinator(files []string, nReduce int) *Coordinator {
-	c := Coordinator{
-		workers: map[string]Worker{},
+func (c *Coordinator) scheduler(files []string, nReduce int) {
+	mapTasks := map[taskId]*mapTask{}
+	for _, f := range files {
+		id, _ := uuid.NewRandom()
+		task := mapTask{
+			Id:     taskId(id.String()),
+			Status: pending,
+			File:   f,
+		}
+		mapTasks[task.Id] = &task
 	}
 
-	// Your code here.
+	reduceTasks := map[int]*reduceTask{}
+	for i := 0; i < nReduce; i++ {
+		task := reduceTask{
+			Partition:         i,
+			Status:            pending,
+			IntermediateFiles: map[string]bool{},
+		}
+		reduceTasks[task.Partition] = &task
+	}
 
-	c.server()
-	return &c
+	mapPhase := make(chan bool, 1)
+	reducePhase := make(chan bool, 1)
+	mapPhase <- true
+
+	go func() {
+		log.Println("started scheduler")
+		for {
+			select {
+			case <-mapPhase:
+				log.Println("scheduling all map tasks")
+				for _, task := range mapTasks {
+					c.scheduledMapTask <- *task
+				}
+			case <-reducePhase:
+				for _, task := range reduceTasks {
+					c.scheduledReduceTask <- *task
+				}
+			case res := <-c.mapResults:
+				log.Println("received a map result")
+				alreadyDone := mapTasks[res.TaskId].Status == done
+				if !alreadyDone {
+					mapTasks[res.TaskId].Status = done
+					for partition, file := range res.IntermediateFiles {
+						reduceTasks[partition].IntermediateFiles[file] = true
+					}
+					doneAll := true
+					for _, task := range mapTasks {
+						doneAll = doneAll && task.Status == done
+					}
+					if doneAll {
+						reducePhase <- true
+					}
+				}
+			case res := <-c.reduceResults:
+				log.Println("received a reduce result")
+				reduceTasks[res.Partition].Status = done
+				doneAll := true
+				for _, task := range reduceTasks {
+					doneAll = doneAll && task.Status == done
+				}
+				if doneAll {
+					c.shutdown()
+					return
+				}
+			case task := <-c.failedMapTask:
+				log.Printf("map task %v failed\n", task.Id)
+				c.scheduledMapTask <- task
+			case task := <-c.failedReduceTask:
+				log.Printf("reduce task %v failed\n", task.Partition)
+				c.scheduledReduceTask <- task
+			}
+		}
+	}()
+}
+
+func (c *Coordinator) shutdown() {
+	close(c.shutdownWorkers) // shutdown workers and server
+	<-c.isServerOffline      // prevents race conditions with c.workers.Done() and c.workers.Wait()
+	c.workers.Wait()         // wait for workers to exit
+	c.done <- true           // map-reduce process is done
 }

--- a/src/mr/coordinator.go
+++ b/src/mr/coordinator.go
@@ -1,18 +1,37 @@
 package mr
 
-import "log"
-import "net"
-import "os"
-import "net/rpc"
-import "net/http"
+import (
+	"log"
+	"net"
+	"net/http"
+	"net/rpc"
+	"os"
+)
 
-
-type Coordinator struct {
-	// Your definitions here.
-
+type Worker struct {
+	socket string
+	status string
 }
 
-// Your code here -- RPC handlers for the worker to call.
+type Coordinator struct {
+	workers map[string]Worker
+}
+
+//
+// RPC handler to register that a worker is idle
+// Should also be used to register a new worker
+//
+func (c *Coordinator) IdleWorker(args *ReportIdleArgs, reply *ReportIdleReply) error {
+	if worker, ok := c.workers[args.Sockname]; ok {
+		worker.status = "IDLE"
+		return nil
+	}
+	c.workers[args.Sockname] = Worker{
+		socket: args.Sockname,
+		status: "IDLE",
+	}
+	return nil
+}
 
 //
 // an example RPC handler.
@@ -23,7 +42,6 @@ func (c *Coordinator) Example(args *ExampleArgs, reply *ExampleReply) error {
 	reply.Y = args.X + 1
 	return nil
 }
-
 
 //
 // start a thread that listens for RPCs from worker.go
@@ -50,7 +68,6 @@ func (c *Coordinator) Done() bool {
 
 	// Your code here.
 
-
 	return ret
 }
 
@@ -60,10 +77,11 @@ func (c *Coordinator) Done() bool {
 // nReduce is the number of reduce tasks to use.
 //
 func MakeCoordinator(files []string, nReduce int) *Coordinator {
-	c := Coordinator{}
+	c := Coordinator{
+		workers: map[string]Worker{},
+	}
 
 	// Your code here.
-
 
 	c.server()
 	return &c

--- a/src/mr/coordinator_test.go
+++ b/src/mr/coordinator_test.go
@@ -1,0 +1,18 @@
+package mr
+
+import "testing"
+
+func Test_IdleWorker(t *testing.T) {
+	coordinator := MakeCoordinator([]string{}, 0)
+	workerSocket := "sock1"
+	args := &ReportIdleArgs{
+		Sockname: workerSocket,
+	}
+	reply := &ReportIdleReply{}
+
+	coordinator.IdleWorker(args, reply)
+
+	if _, ok := coordinator.workers[workerSocket]; !ok {
+		t.Error("expected worker to be known by coordinator")
+	}
+}

--- a/src/mr/rpc.go
+++ b/src/mr/rpc.go
@@ -7,12 +7,22 @@ package mr
 //
 
 import (
+	"context"
+	"fmt"
+	"net/rpc"
 	"os"
 	"strconv"
+
+	"github.com/google/uuid"
 )
+
+type TaskType int
 
 const (
 	sockPrefix = "/var/tmp/824-mr-"
+
+	Map TaskType = iota
+	Reduce
 )
 
 //
@@ -28,34 +38,104 @@ type ExampleReply struct {
 	Y int
 }
 
-type ReportIdleArgs struct {
-	Sockname string
-}
+type Endpoint string
 
-type ReportIdleReply struct{}
+type HealthCheckArgs struct{}
 
-type ResponseErr struct {
+type HealthCheckReply struct{}
+
+type HealthCheckFailedErr struct {
 	Message string
 }
 
-func (re ResponseErr) Error() string {
-	return re.Message
+func (err HealthCheckFailedErr) Error() string {
+	return err.Message
 }
 
-// Add your RPC definitions here.
-func workerSock() string {
-	return uniqueSock()
+type RegistrationRequestArgs struct {
+	WorkerId       string
+	WorkerEndpoint Endpoint
 }
 
-func coordinatorSock() string {
-	return uniqueSock()
+type RegistrationRequestReply struct{}
+
+// Map: Map all key value pairs in the given list of files & write to temporary locations
+// Reduce: Sort all key value pairs in the given list of files & reduce all values belonging to a key
+// -> Assumption: For each key in the given files, all values are present in the files slice
+type WorkRequestArgs struct {
+	WorkerId       string
+	WorkerEndpoint Endpoint
+}
+
+// TODO: better distinguish between map and reduce replies
+type WorkRequestReply struct {
+	TaskId    string
+	TaskType  TaskType
+	Files     []string
+	Partition int
+}
+
+type PartitionId int
+
+type AssignMapTaskArgs struct {
+	TaskId      string
+	File        string
+	NPartitions int
+}
+
+type DoneMapTaskReply struct {
+	PartitionedKVA map[int]string
+}
+
+type AssignReduceTaskArgs struct {
+	Partition     int
+	Intermediates []string
+}
+
+type DoneReduceTaskReply struct{}
+
+type ShutdownArgs struct{}
+
+type ShutdownReply struct{}
+
+func newUniqueEndpoint(id uuid.UUID) Endpoint {
+	s := sockPrefix + id.String()
+	return Endpoint(s)
 }
 
 // Cook up a unique-ish UNIX-domain socket name
 // in /var/tmp, for the coordinator.
 // Can't use the current directory since
 // Athena AFS doesn't support UNIX-domain sockets.
-func uniqueSock() string {
+func coordinatorEndpoint() Endpoint {
 	s := sockPrefix + strconv.Itoa(os.Getuid())
-	return s
+	return Endpoint(s)
+}
+
+//
+// send and RPC request to the given endpoint, wait for the response
+// returns true, if the response was received successfully
+// return false, if something goes wrong
+//
+func call(ctx context.Context, endpoint Endpoint, rpcname string, args interface{}, reply interface{}) error {
+	c, err := rpc.DialHTTP("unix", string(endpoint))
+	if err != nil {
+		return fmt.Errorf("failed dialing: %v", err)
+	}
+	defer c.Close()
+
+	done := make(chan error, 1) // buffer size 1, s.t. the goroutine on the next line does not leak
+	go func() {
+		done <- c.Call(rpcname, args, reply)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return err
+		}
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("request timeout: %v", rpcname)
+	}
 }

--- a/src/mr/rpc.go
+++ b/src/mr/rpc.go
@@ -6,8 +6,14 @@ package mr
 // remember to capitalize all names.
 //
 
-import "os"
-import "strconv"
+import (
+	"os"
+	"strconv"
+)
+
+const (
+	sockPrefix = "/var/tmp/824-mr-"
+)
 
 //
 // example to show how to declare the arguments
@@ -22,15 +28,34 @@ type ExampleReply struct {
 	Y int
 }
 
-// Add your RPC definitions here.
+type ReportIdleArgs struct {
+	Sockname string
+}
 
+type ReportIdleReply struct{}
+
+type ResponseErr struct {
+	Message string
+}
+
+func (re ResponseErr) Error() string {
+	return re.Message
+}
+
+// Add your RPC definitions here.
+func workerSock() string {
+	return uniqueSock()
+}
+
+func coordinatorSock() string {
+	return uniqueSock()
+}
 
 // Cook up a unique-ish UNIX-domain socket name
 // in /var/tmp, for the coordinator.
 // Can't use the current directory since
 // Athena AFS doesn't support UNIX-domain sockets.
-func coordinatorSock() string {
-	s := "/var/tmp/824-mr-"
-	s += strconv.Itoa(os.Getuid())
+func uniqueSock() string {
+	s := sockPrefix + strconv.Itoa(os.Getuid())
 	return s
 }

--- a/src/mr/worker.go
+++ b/src/mr/worker.go
@@ -1,12 +1,34 @@
 package mr
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"io/ioutil"
 	"log"
+	"net"
+	"net/http"
 	"net/rpc"
 	"os"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
 )
+
+type WorkerId string
+
+type Worker struct {
+	Id       WorkerId
+	Endpoint Endpoint
+	Mapf     mapper
+	Reducef  reducer
+	Done     chan bool
+	L        sync.RWMutex
+	Files    []string
+}
 
 //
 // Map functions return a slice of KeyValue.
@@ -30,81 +52,155 @@ func ihash(key string) int {
 // main/mrworker.go calls this function.
 //
 //
-type Mapper func(string, string) []KeyValue
-type Reducer func(string, []string) string
+type mapper func(string, string) []KeyValue
+type reducer func(string, []string) string
 
-func NewWorker(mapf Mapper, reducef Reducer) {
-	sockname := workerSock()
-	err := reportIdle(sockname)
+func NewWorker(mapf mapper, reducef reducer) {
+	id, _ := uuid.NewRandom()
+	endpoint := newUniqueEndpoint(id)
+	w := Worker{
+		Id:       WorkerId(id.String()),
+		Endpoint: endpoint,
+		Mapf:     mapf,
+		Reducef:  reducef,
+		Done:     make(chan bool, 1),
+		L:        sync.RWMutex{},
+		Files:    make([]string, 0),
+	}
+
+	w.server()
+	err := w.requestRegistration()
 	if err != nil {
-		// if the coordinator does not know about us, it does not make sense to wait for work
-		fmt.Fprint(os.Stderr, err)
 		return
 	}
+	<-w.Done
+	w.cleanup()
 }
 
-func reportIdle(sockname string) error {
-	args := ReportIdleArgs{}
-	args.Sockname = sockname
-	reply := ReportIdleReply{}
-	ok := call("Coordinator.IdleWorker", &args, &reply)
-	if !ok {
-		return ResponseErr{
-			Message: "coordinator failed to react on worker reporting idle status",
-		}
-	}
-	fmt.Println("worker has successfully reported to coordinator")
+func (w *Worker) HealthCheck(args *HealthCheckArgs, reply *HealthCheckReply) error {
 	return nil
 }
 
-//
-// example function to show how to make an RPC call to the coordinator.
-//
-// the RPC argument and reply types are defined in rpc.go.
-//
-func CallExample() {
-
-	// declare an argument structure.
-	args := ExampleArgs{}
-
-	// fill in the argument(s).
-	args.X = 99
-
-	// declare a reply structure.
-	reply := ExampleReply{}
-
-	// send the RPC request, wait for the reply.
-	// the "Coordinator.Example" tells the
-	// receiving server that we'd like to call
-	// the Example() method of struct Coordinator.
-	ok := call("Coordinator.Example", &args, &reply)
-	if ok {
-		// reply.Y should be 100.
-		fmt.Printf("reply.Y %v\n", reply.Y)
-	} else {
-		fmt.Printf("call failed!\n")
-	}
-}
-
-//
-// send an RPC request to the coordinator, wait for the response.
-// usually returns true.
-// returns false if something goes wrong.
-//
-func call(rpcname string, args interface{}, reply interface{}) bool {
-	// c, err := rpc.DialHTTP("tcp", "127.0.0.1"+":1234")
-	sockname := coordinatorSock()
-	c, err := rpc.DialHTTP("unix", sockname)
+func (w *Worker) AssignMapTask(args *AssignMapTaskArgs, reply *DoneMapTaskReply) error {
+	log.Printf("map task %v got assigned\n", args.TaskId)
+	file, err := os.Open(args.File)
 	if err != nil {
-		log.Fatal("dialing:", err)
+		return fmt.Errorf("cannot open file %v", args.File)
 	}
-	defer c.Close()
-
-	err = c.Call(rpcname, args, reply)
-	if err == nil {
-		return true
+	content, err := ioutil.ReadAll(file)
+	if err != nil {
+		return fmt.Errorf("cannot read content of %v", args.File)
 	}
-
-	fmt.Println(err)
-	return false
+	file.Close()
+	kva := w.Mapf(args.File, string(content))
+	partitions := map[int]*json.Encoder{}
+	reply.PartitionedKVA = make(map[int]string)
+	for partition := 0; partition < args.NPartitions; partition++ {
+		filename := fmt.Sprintf("mr-%v-%v", args.TaskId, partition)
+		f, err := os.Create(filename)
+		if err != nil {
+			return fmt.Errorf("cannot open intermediate file to store partitioned result")
+		}
+		defer f.Close()
+		w.L.Lock()
+		w.Files = append(w.Files, filename)
+		w.L.Unlock()
+		partitions[partition] = json.NewEncoder(f)
+		reply.PartitionedKVA[partition] = filename
+	}
+	for _, kv := range kva {
+		partition := ihash(kv.Key) % args.NPartitions
+		err := partitions[partition].Encode(&kv)
+		if err != nil {
+			return fmt.Errorf("could not persist kv pair %v,%v", kv.Key, kv.Value)
+		}
+	}
+	return nil
 }
+
+func (w *Worker) AssignReduceTask(args *AssignReduceTaskArgs, reply *DoneReduceTaskReply) error {
+	log.Printf("reduce task for partition %v got assigned\n", args.Partition)
+	var intermediate []KeyValue
+	for _, filename := range args.Intermediates {
+		file, err := os.Open(filename)
+		if err != nil {
+			return fmt.Errorf("cannot open intermediate file %v", filename)
+		}
+		dec := json.NewDecoder(file)
+		var kva []KeyValue
+		for {
+			var kv KeyValue
+			if err := dec.Decode(&kv); err != nil {
+				break
+			}
+			kva = append(kva, kv)
+		}
+		file.Close()
+		intermediate = append(intermediate, kva...)
+	}
+	sort.Sort(byKey(intermediate))
+	tmpFile, err := ioutil.TempFile("", "reduce-")
+	if err != nil {
+		return fmt.Errorf("cannot create temporary file")
+	}
+	i := 0
+	for i < len(intermediate) {
+		j := i + 1
+		for j < len(intermediate) && intermediate[j].Key == intermediate[i].Key {
+			j++
+		}
+		values := []string{}
+		for k := i; k < j; k++ {
+			values = append(values, intermediate[k].Value)
+		}
+		output := w.Reducef(intermediate[i].Key, values)
+		fmt.Fprintf(tmpFile, "%v %v\n", intermediate[i].Key, output)
+		i = j
+	}
+	os.Rename(tmpFile.Name(), fmt.Sprintf("mr-out-%v", args.Partition))
+	return nil
+}
+
+func (w *Worker) Shutdown(args *ShutdownArgs, reply *ShutdownReply) error {
+	close(w.Done)
+	return nil
+}
+
+func (w *Worker) cleanup() {
+	w.L.RLock()
+	for _, filename := range w.Files {
+		os.Remove(filename)
+	}
+	w.L.RUnlock()
+}
+
+func (w *Worker) server() {
+	rpc.Register(w)
+	rpc.HandleHTTP()
+	os.Remove(string(w.Endpoint))
+	l, err := net.Listen("unix", string(w.Endpoint))
+	if err != nil {
+		log.Fatal("listen error:", err)
+	}
+	log.Println("starting worker server")
+	go http.Serve(l, nil)
+}
+
+func (w *Worker) requestRegistration() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	args := RegistrationRequestArgs{
+		WorkerId:       string(w.Id),
+		WorkerEndpoint: w.Endpoint,
+	}
+	reply := RegistrationRequestReply{}
+	return call(ctx, coordinatorEndpoint(), "Coordinator.RequestRegistration", &args, &reply)
+}
+
+// for sorting by key.
+type byKey []KeyValue
+
+// for sorting by key.
+func (a byKey) Len() int           { return len(a) }
+func (a byKey) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byKey) Less(i, j int) bool { return a[i].Key < a[j].Key }


### PR DESCRIPTION
### What this PR does?
- Implements a basic map-reduce algorithm that runs on a distributed file system infrastructure
- Both map and reduce results are written to the distributed file system
--> This is a clear distinction to the original map-reduce paper, as it states that workers keep their map results locally, and reducers request those on demand. This however is clearly more complex to implement, as now workers need to communicate with one another, and the scheduler needs to handle worker failures in a more sophisticated way. A failed health check, needs to recompute all map tasks performed by the dead machine, and notify existing reducers about it. Additionally, we would need to handle the case that all workers are currently busy with reduce tasks, in which case we would need to force one of them to re-execute map tasks.